### PR TITLE
Add new version of dj_fft::fft1d which avoids returning a new std::vector

### DIFF
--- a/dj_fft.h
+++ b/dj_fft.h
@@ -116,7 +116,7 @@ template <typename T> fft_arg<T> fft1d(const fft_arg<T> &xi, const fft_dir &dir)
     int cnt = (int)xi.size();
     int msb = findMSB(cnt);
     T nrm = T(1) / std::sqrt(T(cnt));
-	fft_arg<T> xo(cnt);
+    fft_arg<T> xo(cnt);
 
     // pre-process the input data
     for (int j = 0; j < cnt; ++j)

--- a/dj_fft.h
+++ b/dj_fft.h
@@ -113,7 +113,6 @@ int bitr(uint32_t x, int nb)
 template <typename T> fft_arg<T> fft1d(const fft_arg<T> &xi, const fft_dir &dir)
 {
     DJ_ASSERT((xi.size() & (xi.size() - 1)) == 0 && "invalid input size");
-    DJ_ASSERT(xi.size() == xo.size());
     int cnt = (int)xi.size();
     int msb = findMSB(cnt);
     T nrm = T(1) / std::sqrt(T(cnt));
@@ -156,6 +155,7 @@ template <typename T> fft_arg<T> fft1d(const fft_arg<T> &xi, const fft_dir &dir)
 template <typename T> void fft1d(const fft_arg<T> &xi, fft_arg<T> &xo, const fft_dir &dir)
 {
 	DJ_ASSERT((xi.size() & (xi.size() - 1)) == 0 && "invalid input size");
+    DJ_ASSERT(xi.size() == xo.size());
 	int cnt = (int)xi.size();
 	int msb = findMSB(cnt);
 	T nrm = T(1) / std::sqrt(T(cnt));

--- a/dj_fft.h
+++ b/dj_fft.h
@@ -113,6 +113,7 @@ int bitr(uint32_t x, int nb)
 template <typename T> fft_arg<T> fft1d(const fft_arg<T> &xi, const fft_dir &dir)
 {
     DJ_ASSERT((xi.size() & (xi.size() - 1)) == 0 && "invalid input size");
+    DJ_ASSERT(xi.size() == xo.size());
     int cnt = (int)xi.size();
     int msb = findMSB(cnt);
     T nrm = T(1) / std::sqrt(T(cnt));


### PR DESCRIPTION
I just added this function to my local version, and thought that it might be useful for others as well.

I've not used dj_fft::fft2d or dj_fft::fft3d, but I imagine similar versions can be added for those as well.